### PR TITLE
Enhance Flexibility in Comment Queries: Make GetCommentQueryRequest Optional

### DIFF
--- a/src/modules/support-ticket/dto/request/get-comment-query.request.ts
+++ b/src/modules/support-ticket/dto/request/get-comment-query.request.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { IsNotEmpty, IsNumber, IsOptional } from "class-validator";
+import { toRightNumber } from "src/core/helpers/cast.helper";
+
+export class GetCommentQueryRequest {
+    @Transform(({ value }) => toRightNumber(value, { min: 0 }))
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsNumber()
+    offset: number = 0;
+
+    @Transform(({ value }) => toRightNumber(value, { min: 1 }))
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsNumber()
+    limit: number;
+}

--- a/src/modules/support-ticket/support-ticket.controller.ts
+++ b/src/modules/support-ticket/support-ticket.controller.ts
@@ -29,6 +29,8 @@ import { ChangeTicketStatusRequest } from './dto/request/change-ticket-status.re
 import { SupportTicketStatus } from 'src/infrastructure/data/enums/support-ticket-status.enum';
 import { Roles } from '../authentication/guards/roles.decorator';
 import { Role } from 'src/infrastructure/data/enums/role.enum';
+import { GetCommentQueryRequest } from './dto/request/get-comment-query.request';
+import { query } from 'express';
 
 @ApiBearerAuth()
 @ApiHeader({
@@ -85,13 +87,12 @@ export class SupportTicketController {
         return new ActionResponse<TicketCommentResponse>(result);
     }
 
-    @Get('/comments/:ticketId/:offset/:limit')
+    @Get('/comments/:ticketId')
     async getComments(
         @Param('ticketId') ticketId: string,
-        @Param("offset") offset: number,
-        @Param("limit") limit: number
+        @Query() query: GetCommentQueryRequest
     ): Promise<ActionResponse<TicketCommentResponse[]>> {
-        const comments = await this.ticketCommentService.getCommentsByChunk(ticketId, offset, limit);
+        const comments = await this.ticketCommentService.getCommentsByChunk(ticketId, query);
         const result = plainToInstance(TicketCommentResponse, comments, {
             excludeExtraneousValues: true,
         });

--- a/src/modules/support-ticket/ticket-comment.service.ts
+++ b/src/modules/support-ticket/ticket-comment.service.ts
@@ -11,6 +11,7 @@ import { AddTicketCommentRequest } from './dto/request/add-ticket-comment.reques
 import { Role } from 'src/infrastructure/data/enums/role.enum';
 import { TicketAttachment } from 'src/infrastructure/entities/support-ticket/ticket-attachement.entity';
 import { SupportTicketGateway } from 'src/integration/gateways/support-ticket.gateway';
+import { GetCommentQueryRequest } from './dto/request/get-comment-query.request';
 
 
 @Injectable()
@@ -61,7 +62,9 @@ export class TicketCommentService extends BaseService<TicketComment> {
         return savedComment;
     }
 
-    async getCommentsByChunk(ticketId: string, offset: number, limit: number): Promise<TicketComment[]> {
+    async getCommentsByChunk(ticketId: string, query: GetCommentQueryRequest): Promise<TicketComment[]> {
+        const { limit = 10, offset = 0 } = query;
+
         const supportTicket = await this.supportTicketRepository.findOne({ where: { id: ticketId } })
         if (!supportTicket)
             throw new BadRequestException('Ticket not found');


### PR DESCRIPTION
**Changes Made:**
- Modified the `GetCommentQueryRequest` class to make its properties optional using the `@IsOptional()` decorator.
- Updated the `getCommentsByChunk` method to handle optional query parameters gracefully.

**Description:**
This pull request introduces changes to enhance the flexibility of comment queries for the `getCommentsByChunk` method. The primary focus is on making the comment query parameters optional, allowing for more versatile use cases.

**Details:**
1. **GetCommentQueryRequest Updates:**
   - The `offset` and `limit` properties in the `GetCommentQueryRequest` class have been marked as optional using the `@IsOptional()` decorator. This modification allows clients to make the comment query without providing these parameters, and default values will be used if not specified.

2. **Usage in getCommentsByChunk:**
   - The `getCommentsByChunk` method now gracefully handles optional query parameters. If the `limit` or `offset` is not provided in the `query` object, default values (`10` for `limit` and `0` for `offset`) will be used to ensure backward compatibility.
