### PR TITLE
Add Reason Search By name Endpoint ✨

### DIFF
--- a/src/modules/reason/dto/request/get-reason-by-name-query.request.ts
+++ b/src/modules/reason/dto/request/get-reason-by-name-query.request.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { toRightNumber } from "src/core/helpers/cast.helper";
+
+export class GetReasonByNameQueryRequest {
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    name: string;
+
+    @Transform(({ value }) => toRightNumber(value, { min: 1 }))
+    @ApiProperty({ required: false, minimum: 1 })
+    @IsOptional()
+    @IsNumber()
+    page: number = 1;
+
+    @Transform(({ value }) => toRightNumber(value, { min: 1 }))
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsNumber()
+    limit: number = 5;
+}

--- a/src/modules/reason/dto/request/get-reason-query.requst.ts
+++ b/src/modules/reason/dto/request/get-reason-query.requst.ts
@@ -19,13 +19,11 @@ export class GetReasonQueryRequest {
     @ApiProperty({ required: false, minimum: 1 })
     @IsOptional()
     @IsNumber()
-    page: number;
-  
+    page: number = 1;
+
     @Transform(({ value }) => toRightNumber(value, { min: 1 }))
     @ApiProperty({ required: false })
     @IsOptional()
     @IsNumber()
-    limit: number;
-
-    
+    limit: number = 5;
 }

--- a/src/modules/reason/reason.controller.ts
+++ b/src/modules/reason/reason.controller.ts
@@ -25,6 +25,7 @@ import { Reason } from 'src/infrastructure/entities/reason/reason.entity';
 import { GetReasonQueryRequest } from './dto/request/get-reason-query.requst';
 import { UpdateReasonRequest } from './dto/request/update-reason.request';
 import { PaginatedResponse } from 'src/core/base/responses/paginated.response';
+import { GetReasonByNameQueryRequest } from './dto/request/get-reason-by-name-query.request';
 @ApiBearerAuth()
 @ApiHeader({
     name: 'Accept-Language',
@@ -67,6 +68,16 @@ export class ReasonController {
         return new ActionResponse<Reason>(
             await this.reasonService.getSingleReason(id)
         );
+    }
+
+    @Get("get-reasons-by-name")
+    async getReasonByName(
+        @Query() query: GetReasonByNameQueryRequest
+    ): Promise<ActionResponse<Reason[]>> {
+        const [reasons, count] = await this.reasonService.getReasonByName(query)
+        return new PaginatedResponse<Reason[]>(reasons, {
+            meta: { total: count, page: query.page, limit: query.limit }
+        });
     }
 
     @Patch("update/:id")


### PR DESCRIPTION
### Description: :speech_balloon: 
This pull request introduces enhancements to the Reason Controller and Reason Service to facilitate searching for reasons by name. Additionally, it includes modifications to the DTO for handling the query parameters related to this search functionality.

### Changes Made: :recycle: 

#### Reason Controller: :eyes: 
- Added a new endpoint `GET /get-reasons-by-name` to retrieve reasons by name.
- Implemented `getReasonByName` method in the Reason Controller to handle the new endpoint.
- Utilized the `GetReasonByNameQueryRequest` DTO to parse and validate the request query parameters.
- Utilized `PaginatedResponse` to return a paginated list of reasons along with metadata.

#### Reason Service: :eyes: 
- Implemented `getReasonByName` method in the Reason Service to fetch reasons based on the provided name.
- Utilized the `Like` operator to perform a partial match search on reason names in both English and Arabic.
- Threw a `NotFoundException` if no reasons were found for the provided name.

#### DTO (GetReasonByNameQueryRequest): :eyes: 
- Added a new DTO class `GetReasonByNameQueryRequest` to handle query parameters for searching reasons by name.
- Added validation decorators (`@IsString()`, `@IsNotEmpty()`, `@IsNumber()`, `@IsOptional()`) to ensure the correctness and completeness of the query parameters.
- Applied transformations to ensure that `page` and `limit` are valid numbers and defaulted to 1 and 5 respectively if not provided or invalid.